### PR TITLE
Create macos_autologin_password.sh

### DIFF
--- a/credentials/macos_autologin_password.sh
+++ b/credentials/macos_autologin_password.sh
@@ -1,0 +1,9 @@
+title: macos autologin password
+description: Use ruby to retrieve the MacOS autologin password.
+command: sudo ruby -e 'key = [125, 137, 82, 35, 210, 188, 221, 234, 163, 185, 31]; IO.read("/etc/kcpassword").bytes.each_with_index { |b, i| break if key.include?(b); print [b ^ key[i % key.size]].pack("U*") }'
+function: |
+  function macos_autologin_password() {
+    sudo $(which ruby) -e 'key = [125, 137, 82, 35, 210, 188, 221, 234, 163, 185, 31]; IO.read("/etc/kcpassword").bytes.each_with_index { |b, i| break if key.include?(b); print [b ^ key[i % key.size]].pack("U*") }'
+  }
+params:
+tags: [credential, hash, macos]


### PR DESCRIPTION
Created a page that shows a one-liner to reveal the MacOS autologin password.